### PR TITLE
Improve transformer training with pseudo labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,14 +7,23 @@ from sklearn.cluster import KMeans
 from modules.autoencoder import Autoencoder
 from modules.transformer_model import TransformerClusterNet
 from modules.classic_methods import cluster_classical_methods
-from utils.preprocessing import load_hsi_data, normalize, visualize_clusters, load_ground_truth, plot_comparison
+from utils.preprocessing import (
+    load_hsi_data,
+    normalize,
+    visualize_clusters,
+    load_ground_truth,
+    plot_comparison,
+)
 from utils.evaluation import evaluate_all
+
 
 # 设置
 DATA_PATH = 'data/Salinas_corrected.mat'
 GT_PATH = 'data/Salinas_gt.mat'
 N_CLUSTERS = 16   # Salinas 有 16 类
 EPOCHS = 50
+TRANS_EPOCHS = 20
+CLUSTER_LR = 1e-4
 LATENT_DIM = 64
 DEVICE = 'cuda' if torch.cuda.is_available() else 'cpu'
 # 根据显存限制决定一次送入 Transformer 的像素数量
@@ -31,7 +40,11 @@ def main():
     # 2. 构建模型
     print("Building models...")
     autoencoder = Autoencoder(input_dim=X.shape[1], latent_dim=LATENT_DIM).to(DEVICE)
-    transformer = TransformerClusterNet(embed_dim=LATENT_DIM, output_dim=LATENT_DIM).to(DEVICE)
+    transformer = TransformerClusterNet(
+        embed_dim=LATENT_DIM,
+        output_dim=LATENT_DIM,
+        n_clusters=N_CLUSTERS,
+    ).to(DEVICE)
 
     # 3. 训练 Autoencoder
     print("Training autoencoder...")
@@ -48,30 +61,59 @@ def main():
         if epoch % 10 == 0 or epoch == EPOCHS - 1:
             print(f"Epoch {epoch:02d}: MSE Loss = {loss.item():.4f}")
 
-    # 4. Transformer 特征提取
-    print("Extracting features with transformer...")
+    # 4. 提取 Autoencoder 特征用于 Transformer 训练
+    print("Preparing features for transformer training...")
     autoencoder.eval()
     with torch.no_grad():
-        features, _ = autoencoder(torch.tensor(X, dtype=torch.float32).to(DEVICE))
-        features = features.to(DEVICE)
-        if features.size(0) <= SEQ_BATCH:
-            # 所有像素作为一个序列送入 Transformer
-            seq = features.unsqueeze(0)  # (1, N, D)
+        ae_features, _ = autoencoder(torch.tensor(X, dtype=torch.float32).to(DEVICE))
+        ae_features = ae_features.to(DEVICE)
+
+    # 5. 使用 KMeans 生成伪标签训练 Transformer
+    print("Generating pseudo labels with KMeans...")
+    init_labels = KMeans(n_clusters=N_CLUSTERS, random_state=0).fit_predict(
+        ae_features.cpu().numpy()
+    )
+    pseudo_labels = torch.tensor(init_labels, dtype=torch.long, device=DEVICE)
+
+    print("Training transformer with pseudo labels...")
+    optimizer_t = optim.Adam(transformer.parameters(), lr=CLUSTER_LR)
+    ce_loss = nn.CrossEntropyLoss()
+    transformer.train()
+    for epoch in range(TRANS_EPOCHS):
+        perm = torch.randperm(ae_features.size(0))
+        for i in range(0, ae_features.size(0), SEQ_BATCH):
+            idx = perm[i : i + SEQ_BATCH]
+            chunk = ae_features[idx]
+            labs = pseudo_labels[idx]
+            _, logits = transformer(chunk.unsqueeze(0), return_logits=True)
+            logits = logits.squeeze(0)
+            loss = ce_loss(logits, labs)
+            optimizer_t.zero_grad()
+            loss.backward()
+            optimizer_t.step()
+        if epoch % 5 == 0 or epoch == TRANS_EPOCHS - 1:
+            print(f"Transformer Epoch {epoch:02d}: CE Loss = {loss.item():.4f}")
+
+    # 6. Transformer 特征提取
+    print("Extracting features with transformer...")
+    transformer.eval()
+    with torch.no_grad():
+        if ae_features.size(0) <= SEQ_BATCH:
+            seq = ae_features.unsqueeze(0)  # (1, N, D)
             embed = transformer(seq).squeeze(0).cpu().numpy()
         else:
-            # 分批送入 Transformer，每批作为一个序列
             outputs = []
-            for i in range(0, features.size(0), SEQ_BATCH):
-                chunk = features[i:i + SEQ_BATCH].unsqueeze(0)
+            for i in range(0, ae_features.size(0), SEQ_BATCH):
+                chunk = ae_features[i : i + SEQ_BATCH].unsqueeze(0)
                 out = transformer(chunk).squeeze(0)
                 outputs.append(out.cpu())
             embed = torch.cat(outputs, dim=0).numpy()
 
-    # 5. 聚类（Transformer + KMeans）
+    # 7. 聚类（Transformer + KMeans）
     print("Clustering with KMeans...")
     pred_labels = KMeans(n_clusters=N_CLUSTERS, random_state=42).fit_predict(embed)
 
-    # 6. 可视化 + 评估
+    # 8. 可视化 + 评估
     visualize_clusters(pred_labels, H, W, title='Transformer + KMeans Clustering', save_path='views/transformer_kmeans.png')
     gt = load_ground_truth(GT_PATH).reshape(-1)
     mask = gt > 0

--- a/modules/transformer_model.py
+++ b/modules/transformer_model.py
@@ -25,13 +25,18 @@ class TransformerEncoderLayer(nn.Module):
         return x
 
 class TransformerClusterNet(nn.Module):
-    def __init__(self, embed_dim=64, output_dim=64, n_layers=2):
+    def __init__(self, embed_dim=64, output_dim=64, n_layers=2, n_clusters=None, max_seq_len=8192):
         super().__init__()
         self.input_proj = nn.Linear(embed_dim, embed_dim)
-        self.encoder = nn.Sequential(*[TransformerEncoderLayer(embed_dim) for _ in range(n_layers)])
+        self.pos_embed = nn.Parameter(torch.randn(1, max_seq_len, embed_dim))
+        self.encoder = nn.Sequential(
+            *[TransformerEncoderLayer(embed_dim) for _ in range(n_layers)]
+        )
         self.output_proj = nn.Linear(embed_dim, output_dim)
+        self.cls_head = nn.Linear(output_dim, n_clusters) if n_clusters is not None else None
+        self.max_seq_len = max_seq_len
 
-    def forward(self, x):
+    def forward(self, x, return_logits=False):
         """Forward pass.
 
         Parameters
@@ -55,9 +60,27 @@ class TransformerClusterNet(nn.Module):
             orig_2d = True
 
         x = self.input_proj(x)
+
+        seq_len = x.size(1)
+        if seq_len > self.max_seq_len:
+            raise ValueError(
+                f"Sequence length {seq_len} exceeds maximum {self.max_seq_len}."
+            )
+        pos_emb = self.pos_embed[:, :seq_len, :]
+        x = x + pos_emb
+
         x = self.encoder(x)
-        x = self.output_proj(x)
+        feat = self.output_proj(x)
+
+        logits = None
+        if return_logits and self.cls_head is not None:
+            logits = self.cls_head(feat)
 
         if orig_2d:
-            return x.squeeze(1)
-        return x
+            feat = feat.squeeze(1)
+            if logits is not None:
+                logits = logits.squeeze(1)
+
+        if return_logits and logits is not None:
+            return feat, logits
+        return feat


### PR DESCRIPTION
## Summary
- update `TransformerClusterNet` to support optional classification head
- pretrain transformer using pseudo labels from KMeans

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687439341178833193ae43dd71d9545f